### PR TITLE
Adding the VIM jellybeans theme

### DIFF
--- a/theme/jellybeans.json
+++ b/theme/jellybeans.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://code-syntax-addon.github.io/code-syntax/schemas/theme/v1.json",
+  "description": "Jellybeans - A colorful, dark color scheme translated from Vim",
+  "default": {
+    "foreground": "#e8e8d3",
+    "background": "#151515"
+  },
+  "codeMirror": {
+    "keyword": "#8197bf",
+    "atom": "#cf6a4c",
+    "number": "#cf6a4c",
+    "def": "#fad07a",
+    "variable": "#e8e8d3",
+    "punctuation": "#668799",
+    "property": "#c6b6ee",
+    "operator": "#8197bf",
+    "type": "#ffb964",
+    "comment": {
+      "foreground": "#888888",
+      "italic": true
+    },
+    "string": "#99ad6a",
+    "string-2": "#556633",
+    "meta": "#8fbfdc",
+    "builtin": "#fad07a",
+    "tag": "#8197bf",
+    "attribute": "#ffb964",
+    "error": "#902020"
+  },
+  "spans": {
+    "string": "#99ad6a",
+    "number": "#cf6a4c",
+    "keyword": "#8197bf"
+  },
+  "modes": {
+    "python": {
+      "codeMirror": {
+        "operator": "#8197bf"
+      }
+    },
+    "js": {
+      "codeMirror": {
+        "atom": "#cf6a4c"
+      }
+    },
+    "c": {
+      "codeMirror": {
+        "operator": "#cf6a4c"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds the Jellybeans color scheme to the Code Syntax Add-on. Jellybeans is a classic, high-contrast dark theme originally created for Vim, known for its balanced use of colors that improve readability without being too harsh on the eyes.


<img width="1137" height="503" alt="Captura de pantalla 2026-02-07 181216" src="https://github.com/user-attachments/assets/29873394-19de-499e-9e1f-46b33071ab74" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Jellybeans color theme for syntax highlighting with support for multiple programming languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->