### PR TITLE
Harden formatting against Apps Script runtime errors

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@types/google-apps-script": "^1.0.83"
+        "@types/google-apps-script": "^2.0.11"
       }
     },
     "node_modules/@types/google-apps-script": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@types/google-apps-script/-/google-apps-script-1.0.83.tgz",
-      "integrity": "sha512-o+QNeNZxPAfYHzRiLHjub9qF0IILg21r9MzYlnrIHUT+/wcC70aqDfedmzKTgtzsj79zvoTZD0cjGgy46+1Ynw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/google-apps-script/-/google-apps-script-2.0.11.tgz",
+      "integrity": "sha512-D+UWQKXUd4KgScQ+iqqx4jYxZXmU7cYCWHlikmUckIfFvblTcG4d3tQsjJAA261wmFZOya+WWd8L6/0bvSLjHQ==",
       "license": "MIT"
     }
   }

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@types/google-apps-script": "^1.0.83"
+    "@types/google-apps-script": "^2.0.11"
   }
 }

--- a/docs/syntax.ts
+++ b/docs/syntax.ts
@@ -136,6 +136,18 @@ function getColorToMode() : Map<string, string> {
   return COLOR_TO_MODE!;
 }
 
+function getActiveSelection() : docs.Range | null {
+  const retryDelays = [100, 300];
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return DocumentApp.getActiveDocument().getSelection();
+    } catch (e) {
+      if (attempt >= retryDelays.length) throw e;
+      Utilities.sleep(retryDelays[attempt]);
+    }
+  }
+}
+
 for (let mode of theme.getModeList()) {
   let self : any = this;
   self[changeColorNameFor(mode)] = function() {
@@ -152,7 +164,7 @@ function changeColorTo(mode : string) {
   if (cursor != null) {
     element = cursor.getElement();
   } else {
-    const selection = DocumentApp.getActiveDocument().getSelection();
+    const selection = getActiveSelection();
     if (selection != null) {
       const rangeElements = selection.getRangeElements();
       if (rangeElements.length == 1) {
@@ -207,7 +219,7 @@ function colorize() {
 }
 
 function colorizeSelectionAs(mode : string) {
-  let selection = DocumentApp.getActiveDocument().getSelection();
+  let selection = getActiveSelection();
   if (selection == null) return;
   let rangeElements = selection.getRangeElements();
   let lines : Array<string> = []
@@ -438,13 +450,17 @@ function moveParagraphsIntoTables(segment : CodeSegment) {
     parent.asBody().appendParagraph("");
   }
 
+  let movedParagraphs : Array<Paragraph> = [];
   for (let para of paras) {
+    let indentStart = para.getIndentStart();
+    let indentFirstLine = para.getIndentFirstLine();
     para.removeFromParent();
-    cell.appendParagraph(para);
+    let movedParagraph = cell.appendParagraph(para);
+    movedParagraphs.push(movedParagraph);
     if (minStart !== null) {
       // Remove the indentation. We will indent the table instead.
-      para.setIndentStart(para.getIndentStart() - minStart);
-      para.setIndentFirstLine(para.getIndentFirstLine() - minStart);
+      movedParagraph.setIndentStart(indentStart - minStart);
+      movedParagraph.setIndentFirstLine(indentFirstLine - minStart);
     }
     // No need to change the right indentation, since it's absolute and
     // thus works in the table.
@@ -452,6 +468,7 @@ function moveParagraphsIntoTables(segment : CodeSegment) {
 
   // Remove the automatically inserted empty paragraph.
   cell.removeChild(cell.getChild(0));
+  segment.paragraphs = movedParagraphs;
 
   if (minStart !== null && minStart !== 0) {
     // We can't change the indentation of tables in Google Apps Script.
@@ -472,7 +489,15 @@ function moveParagraphsIntoTables(segment : CodeSegment) {
         .setPaddingRight(0);
     secondCell.setWidth(computeDefaultWidth() - minStart - 2);
     table.removeFromParent();
-    secondCell.appendTable(table);
+    table = secondCell.appendTable(table);
+    // appendTable inserts a copy. Keep references to the elements that are
+    // actually attached to the document.
+    cell = table.getCell(0, 0);
+    segment.cell = cell;
+    segment.paragraphs = [];
+    for (let i = 0; i < cell.getNumChildren(); i++) {
+      segment.paragraphs.push(cell.getChild(i).asParagraph());
+    }
     // Tables seem to require a lines around a table. Add a second one and change
     // their size to 0.
     secondCell.appendParagraph("");
@@ -481,10 +506,30 @@ function moveParagraphsIntoTables(segment : CodeSegment) {
   }
 }
 
+function hasBacktickDelimiters(segment : CodeSegment) : boolean {
+  let paragraphs = segment.paragraphs;
+  if (paragraphs.length == 0) return false;
+  let first = paragraphs[0];
+  let firstText = first.getText();
+  if (!firstText.startsWith("```")) return false;
+  let last = paragraphs[paragraphs.length - 1]
+  let lastText = last.getText();
+  let lineBreak = lastText.lastIndexOf("\r");
+  if (lineBreak != -1) {
+    return lastText.substring(lineBreak + 1, lineBreak + 4) == "```";
+  }
+  // A segment contained in one paragraph needs separate opening and closing
+  // lines. Otherwise this is only an opening delimiter.
+  if (first === last) return false;
+  return lastText.startsWith("```");
+}
+
 function removeBackticks(segment : CodeSegment) {
+  // The document may have changed since findCodeSegments ran.
+  if (!hasBacktickDelimiters(segment)) return;
+
   let paragraphs = segment.paragraphs;
   let first = paragraphs[0];
-  if (!first.getText().startsWith("```")) throw "Unexpected code segment";
   let last = paragraphs[paragraphs.length - 1]
   let lineBreak = first.getText().indexOf("\r");
   if (lineBreak != -1) {
@@ -496,10 +541,8 @@ function removeBackticks(segment : CodeSegment) {
   let lastText = last.getText();
   lineBreak = lastText.lastIndexOf("\r");
   if (lineBreak != -1) {
-    if (lastText.substring(lineBreak + 1, lineBreak + 4) != "```") throw "Unexpected code segment";
     last.editAsText().deleteText(lineBreak, lastText.length - 1);  // deleteText is inclusive.
   } else {
-    if (!last.getText().startsWith("```")) throw "Unexpected code segment";
     last.removeFromParent();
     paragraphs.length--;
   }
@@ -514,6 +557,9 @@ function removeBackticks(segment : CodeSegment) {
 function boxSegments(segments : Array<CodeSegment>) {
   for (let segment of segments) {
     if (!segment.cell) {
+      // The document may have changed since findCodeSegments ran. Do not
+      // restructure a segment unless both delimiters are still present.
+      if (!hasBacktickDelimiters(segment)) continue;
       moveParagraphsIntoTables(segment);
       // By removing the backticks, we might remove all paragraphs of it.
       removeBackticks(segment);
@@ -669,7 +715,15 @@ function highlightCodeSpansAndHeadings(segments : Array<CodeSegment>) {
 
 function highlightCodeSpan(para : Paragraph, startTick : number, endTick : number) {
   let text = para.editAsText();
-  let str = para.getText().substring(startTick + 1, endTick);
+  let currentText = text.getText();
+  if (startTick < 0 ||
+      endTick >= currentText.length ||
+      currentText.charAt(startTick) != "`" ||
+      currentText.charAt(endTick) != "`") {
+    // The paragraph changed after its code spans were identified.
+    return;
+  }
+  let str = currentText.substring(startTick + 1, endTick);
   let style = getThemer().getCodeSpanStyle(str);
   applyStyle(text, startTick, endTick, style);
 

--- a/slides/package-lock.json
+++ b/slides/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@types/google-apps-script": "^1.0.83"
+        "@types/google-apps-script": "^2.0.11"
       }
     },
     "node_modules/@types/google-apps-script": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@types/google-apps-script/-/google-apps-script-1.0.83.tgz",
-      "integrity": "sha512-o+QNeNZxPAfYHzRiLHjub9qF0IILg21r9MzYlnrIHUT+/wcC70aqDfedmzKTgtzsj79zvoTZD0cjGgy46+1Ynw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/google-apps-script/-/google-apps-script-2.0.11.tgz",
+      "integrity": "sha512-D+UWQKXUd4KgScQ+iqqx4jYxZXmU7cYCWHlikmUckIfFvblTcG4d3tQsjJAA261wmFZOya+WWd8L6/0bvSLjHQ==",
       "license": "MIT"
     }
   }

--- a/slides/package.json
+++ b/slides/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@types/google-apps-script": "^1.0.83"
+    "@types/google-apps-script": "^2.0.11"
   }
 }

--- a/slides/syntax.ts
+++ b/slides/syntax.ts
@@ -180,6 +180,7 @@ for (let mode of theme.getModeList()) {
 function changeColorTo(mode : string) {
   let selection = SlidesApp.getActivePresentation().getSelection();
   let elementRange = selection.getPageElementRange();
+  if (!elementRange) return;
   elementRange.getPageElements().forEach(function(pe) {
     changeColorOfPageElement(pe, mode);
   });
@@ -225,6 +226,7 @@ function colorize() {
 function colorizeSlide() {
   let selection = SlidesApp.getActivePresentation().getSelection();
   let currentPage = selection.getCurrentPage();
+  if (!currentPage) return;
   if (currentPage.getPageType() != SlidesApp.PageType.SLIDE) return;
   let slide = currentPage.asSlide();
   doSlide(slide);
@@ -279,8 +281,20 @@ function isBoxedCodeShape(shape : Shape) : boolean {
   return getColorToMode().has(hexColor);
 }
 
+function getShapeText(shape : Shape) : TextRange | null {
+  try {
+    return shape.getText();
+  } catch (e) {
+    // Slides may reject getText for some shapes, even though they are exposed
+    // as Shape page elements.
+    return null;
+  }
+}
+
 function isTextCodeShape(shape : Shape) : boolean {
-  let str = shape.getText().asString();
+  let text = getShapeText(shape);
+  if (!text) return false;
+  let str = text.asString();
   if (!str.startsWith("```")) return false;
   let lastTicksN = str.lastIndexOf('\n```');
   let lastTicksV = str.lastIndexOf('\v```'); // Vertical tab.
@@ -354,15 +368,8 @@ function colorizeText(text : TextRange, mode : string) {
 }
 
 function colorizeSpans(shape : Shape) {
-  let text : TextRange | null = null;
-  try {
-    text = shape.getText();
-  } catch (e) {
-    // We don't know why this happens, but we have seen stack traces
-    // with it.
-    return;
-  }
-  if (text == null) return;
+  let text = getShapeText(shape);
+  if (!text) return;
   if (text.isEmpty()) return;
   let str = text.asString();
   let spans : Array<CodeSpan> = [];

--- a/theme/package-lock.json
+++ b/theme/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@types/google-apps-script": "^1.0.83"
+        "@types/google-apps-script": "^2.0.11"
       }
     },
     "node_modules/@types/google-apps-script": {
-      "version": "1.0.83",
-      "resolved": "https://registry.npmjs.org/@types/google-apps-script/-/google-apps-script-1.0.83.tgz",
-      "integrity": "sha512-o+QNeNZxPAfYHzRiLHjub9qF0IILg21r9MzYlnrIHUT+/wcC70aqDfedmzKTgtzsj79zvoTZD0cjGgy46+1Ynw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/google-apps-script/-/google-apps-script-2.0.11.tgz",
+      "integrity": "sha512-D+UWQKXUd4KgScQ+iqqx4jYxZXmU7cYCWHlikmUckIfFvblTcG4d3tQsjJAA261wmFZOya+WWd8L6/0bvSLjHQ==",
       "license": "MIT"
     }
   }

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@types/google-apps-script": "^1.0.83"
+    "@types/google-apps-script": "^2.0.11"
   }
 }

--- a/theme/schema.json
+++ b/theme/schema.json
@@ -100,16 +100,17 @@
           "description": "The background color for code blocks. Must be unique per mode.",
           "type": "string",
           "pattern": "^#[0-9A-Fa-f]{6}$"
+        },
+        "style": {
+          "description": "The style for every element that doesn't have a code-mirror style.",
+          "$ref": "#/$defs/StyleOrColor"
+        },
+        "codeMirror": {
+          "description": "The syntax highlighting for this mode.",
+          "$ref": "#/$defs/CodeMirror"
         }
       },
-      "style": {
-        "description": "The style for every element that doesn't have a code-mirror style.",
-        "$ref": "#/$defs/StyleOrColor"
-      },
-      "codeMirror": {
-        "description": "The syntax highlighting for this mode.",
-        "$ref": "#/$defs/CodeMirror"
-      }
+      "additionalProperties": false
     },
     "CodeMirror": {
       "description": "The syntax highlighting for code sections. The keys are the CodeMirror classes.",

--- a/theme/theme.ts
+++ b/theme/theme.ts
@@ -57,18 +57,26 @@ type Mode = {
   codeMirror? : Record<string, StyleOrColor>;
 }
 
+const COLOR_PATTERN = /^#[0-9A-Fa-f]{6}$/;
+
+function checkColor(path: Array<string>, value: any): void {
+  if (typeof value !== 'string' || !COLOR_PATTERN.test(value)) {
+    throw new Error(`Invalid color ${path.join('.')}: ${JSON.stringify(value)}. Expected #RRGGBB`);
+  }
+}
+
 function checkMode(path: Array<string>, value: any): void {
   if (typeof value !== 'object') {
     throw new Error(`Invalid Syntax ${path.join('.')}: ${JSON.stringify(value)}`);
   }
-  if (value.default !== undefined) {
-    checkStyleOrColor([...path, 'default'], value.default);
+  if (value.style !== undefined) {
+    checkStyleOrColor([...path, 'style'], value.style);
   }
-  if (value.syntax !== undefined) {
-    checkRecord([...path, 'syntax'], value.syntax, checkStyleOrColor);
+  if (value.codeMirror !== undefined) {
+    checkRecord([...path, 'codeMirror'], value.codeMirror, checkStyleOrColor);
   }
-  if (value.modeColor !== undefined && typeof value.modeColor !== 'string') {
-    throw new Error(`Invalid 'modeColor' in Mode ${path.join('.')}: ${JSON.stringify(value.modeColor)}`);
+  if (value.modeColor !== undefined) {
+    checkColor([...path, 'modeColor'], value.modeColor);
   }
 }
 
@@ -94,18 +102,21 @@ function checkStyle(path: Array<string>, value: any): void {
   if (value.bold !== undefined && typeof value.bold !== 'boolean') {
     throw new Error(`Invalid 'bold' in Style ${path.join('.')}: ${JSON.stringify(value.bold)}`);
   }
-  if (value.foreground !== undefined && typeof value.foreground !== 'string') {
-    throw new Error(`Invalid 'foreground' in Style ${path.join('.')}: ${JSON.stringify(value.foreground)}`);
+  if (value.foreground !== undefined) {
+    checkColor([...path, 'foreground'], value.foreground);
   }
-  if (value.background !== undefined && typeof value.background !== 'string') {
-    throw new Error(`Invalid 'background' in Style ${path.join('.')}: ${JSON.stringify(value.background)}`);
+  if (value.background !== undefined) {
+    checkColor([...path, 'background'], value.background);
   }
 }
 
 type StyleOrColor = string | Style;
 
 function checkStyleOrColor(path: Array<string>, value: any): void {
-  if (typeof value === 'string') return;
+  if (typeof value === 'string') {
+    checkColor(path, value);
+    return;
+  }
   checkStyle(path, value);
 }
 
@@ -123,8 +134,8 @@ function checkTheme(path: Array<string>, value: any): void {
   if (value.default !== undefined) {
     checkStyleOrColor([...path, 'default'], value.default);
   }
-  if (value.syntax !== undefined) {
-    checkRecord([...path, 'syntax'], value.syntax, checkStyleOrColor);
+  if (value.codeMirror !== undefined) {
+    checkRecord([...path, 'codeMirror'], value.codeMirror, checkStyleOrColor);
   }
   if (value.spans !== undefined) {
     checkRecord([...path, 'spans'], value.spans, checkStyleOrColor);
@@ -392,14 +403,24 @@ const DEFAULT_THEME : Theme = {
 
 const THEME_PROPERTY_KEY = "theme";
 
-function newThemer(documentTheme : string | null, userTheme : string | null) : Themer {
-  if (documentTheme) {
-    return new Themer(JSON.parse(documentTheme));
-  } else if (userTheme) {
-    return new Themer(JSON.parse(userTheme));
-  } else {
-    return new Themer(DEFAULT_THEME);
+function parseTheme(theme : string | null, source : string) : Theme | null {
+  if (!theme) return null;
+  try {
+    let parsed = JSON.parse(theme);
+    checkTheme([], parsed);
+    return parsed;
+  } catch (e) {
+    console.error(`Ignoring invalid ${source} theme: ${e.message}`);
+    return null;
   }
+}
+
+function newThemer(documentTheme : string | null, userTheme : string | null) : Themer {
+  let parsedDocumentTheme = parseTheme(documentTheme, "document");
+  if (parsedDocumentTheme) return new Themer(parsedDocumentTheme);
+  let parsedUserTheme = parseTheme(userTheme, "user");
+  if (parsedUserTheme) return new Themer(parsedUserTheme);
+  return new Themer(DEFAULT_THEME);
 }
 
 function showThemes(


### PR DESCRIPTION
## Summary

- retry transient Google Docs selection lookup failures before formatting starts
- retain attached Docs elements after paragraph and table copies, and revalidate stale code delimiters and spans
- handle nullable Slides selections and shapes whose text cannot be read
- validate custom theme colors and safely ignore invalid stored themes
- update Google Apps Script type definitions to 2.0.11

## Validation

- TypeScript compilation for Docs, Slides, and theme sources
- JSON parsing for the theme schema
- `git diff --check`

Fixes #37