### PR TITLE
Reduce Apps Script calls during syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ examples of themes.
 If you want to contribute a [theme](https://code-syntax-addon.github.io/code-syntax/themes.html),
 please create a pull request on the `gh-pages` branch.
 
+## Testing
+
+See the [test documentation](tests/README.md) for local regression tests and
+the end-to-end smoke-test procedure.
+
 ## Kodify
 This add-on was inspired by "Kodify", a google-docs extension that was
 available at Google (go/kodify).

--- a/docs/syntax.ts
+++ b/docs/syntax.ts
@@ -203,10 +203,11 @@ class CodeSegment {
 
 function colorize() {
   let document = DocumentApp.getActiveDocument();
-  let codeSegments = findCodeSegments(document.getBody());
+  let paragraphs : Array<Paragraph> = [];
+  let codeSegments = findCodeSegments(document.getBody(), paragraphs);
   // Highlight code spans before we filter out the unknown code segments.
   // We don't want to modify unknown segments at all.
-  highlightCodeSpansAndHeadings(codeSegments);
+  highlightCodeSpansAndHeadings(codeSegments, paragraphs);
 
   // Filter out segments where we don't know the mode.
   // Otherwise we would remove the mode line, without giving the user a chance
@@ -223,7 +224,8 @@ function colorizeSelectionAs(mode : string) {
   if (selection == null) return;
   let rangeElements = selection.getRangeElements();
   let lines : Array<string> = []
-  let texts : Array<Array<any>> = []
+  let texts : Array<{text : Text, offset : number}> = []
+  let runs : Array<TextStyleRun> = [];
 
   let codeMirrorStyle = getModeToStyle().get(mode)!;
 
@@ -254,20 +256,12 @@ function colorizeSelectionAs(mode : string) {
       if (length == 0) continue;
 
       let to = from + length - 1;
-      let defaultStyle = codeMirrorStyle.defaultStyle;
-      let fontFamily = defaultStyle.fontFamily;
-      if (fontFamily) text.setFontFamily(from, to, fontFamily);
-      let foreground = defaultStyle.foreground;
-      if (foreground) text.setForegroundColor(from, to, foreground);
-      let background = defaultStyle.background;
-      if (background) text.setBackgroundColor(from, to, background);
-      if (defaultStyle.bold !== undefined) text.setBold(from, to, defaultStyle.bold);
-      if (defaultStyle.italic !== undefined) text.setItalic(from, to, defaultStyle.italic);
+      applyStyle(text, from, to, codeMirrorStyle.defaultStyle);
       let elementLines = content.split("\r");
       let offset = from;
       for (let line of elementLines) {
         lines.push(line);
-        texts.push([text, offset]);
+        texts.push({text: text, offset: offset});
         offset += line.length + 1;
       }
     }
@@ -281,11 +275,15 @@ function colorizeSelectionAs(mode : string) {
       return;
     }
     let current = texts[lineIndex];
-    let text = current[0];
-    let offset = current[1];
-    applyCodeMirrorStyle(codeMirrorStyle, text, offset + lineOffset, token, style)
+    appendTextStyleRun(
+        runs,
+        current.text,
+        current.offset + lineOffset,
+        token.length,
+        codeMirrorStyle.codeMirrorStyleToStyleDelta(style));
     lineOffset += token.length;
   });
+  applyTextStyleRuns(runs);
 }
 
 let defaultWidth : number | null = null;
@@ -327,20 +325,20 @@ function codeSegmentFromCodeTable(table : Table) : CodeSegment {
   return codeSegment;
 }
 
-function findCodeSegmentsInTable(table : Table) : Array<CodeSegment> {
+function findCodeSegmentsInTable(table : Table, paragraphs : Array<Paragraph>) : Array<CodeSegment> {
   let result : Array<CodeSegment> = [];
   for (let i = 0; i < table.getNumRows(); i++) {
     let row = table.getRow(i);
     for (let j = 0; j < row.getNumCells(); j++) {
       let cell = row.getCell(j);
-      let segments = findCodeSegments(cell);
+      let segments = findCodeSegments(cell, paragraphs);
       result.push(...segments);
     }
   }
   return result;
 }
 
-function findCodeSegments(container : Body | TableCell) : Array<CodeSegment> {
+function findCodeSegments(container : Body | TableCell, paragraphs : Array<Paragraph>) : Array<CodeSegment> {
   let result : Array<CodeSegment> = []
   let inCodeSegment = false;
   let accumulated : Array<Paragraph> | null = [];
@@ -374,15 +372,18 @@ function findCodeSegments(container : Body | TableCell) : Array<CodeSegment> {
     if (element.getType() == DocumentApp.ElementType.TABLE) {
       let table = element.asTable();
       if (isCodeTable(table)) {
-        result.push(codeSegmentFromCodeTable(table));
+        let segment = codeSegmentFromCodeTable(table);
+        result.push(segment);
+        paragraphs.push(...segment.paragraphs);
       } else {
-        let nested = findCodeSegmentsInTable(element.asTable());
+        let nested = findCodeSegmentsInTable(element.asTable(), paragraphs);
         result.push(...nested);
       }
     }
     if (element.getType() != DocumentApp.ElementType.PARAGRAPH) continue;
 
     let paragraph = element.asParagraph();
+    paragraphs.push(paragraph);
     let text = paragraph.getText()
     if (text.startsWith("```")) {
       if (!inCodeSegment) {
@@ -475,18 +476,19 @@ function moveParagraphsIntoTables(segment : CodeSegment) {
     // As a work-around we create another invisible table. It's an ugly hack, but
     //   unfortunately seems to be the only way.
     let indentTable = insertTableAt(parent, index);
-    let attributes = indentTable.getAttributes();
-    attributes["BORDER_WIDTH"] = 0;
-    indentTable.setAttributes(attributes);
+    let indentAttributes : any = {};
+    indentAttributes[DocumentApp.Attribute.BORDER_WIDTH] = 0;
+    indentTable.setAttributes(indentAttributes);
 
     let row = indentTable.appendTableRow();
     row.appendTableCell().setWidth(minStart);
     let secondCell = row.appendTableCell();
-    secondCell
-        .setPaddingTop(0)
-        .setPaddingBottom(0)
-        .setPaddingLeft(0)
-        .setPaddingRight(0);
+    let secondCellAttributes : any = {};
+    secondCellAttributes[DocumentApp.Attribute.PADDING_TOP] = 0;
+    secondCellAttributes[DocumentApp.Attribute.PADDING_BOTTOM] = 0;
+    secondCellAttributes[DocumentApp.Attribute.PADDING_LEFT] = 0;
+    secondCellAttributes[DocumentApp.Attribute.PADDING_RIGHT] = 0;
+    secondCell.setAttributes(secondCellAttributes);
     secondCell.setWidth(computeDefaultWidth() - minStart - 2);
     table.removeFromParent();
     table = secondCell.appendTable(table);
@@ -567,28 +569,69 @@ function boxSegments(segments : Array<CodeSegment>) {
 
     let style = getModeToStyle().get(segment.mode)!;
     let cell = segment.cell!;
-    cell.setBackgroundColor(style.background);
+    let cellAttributes : any = {};
+    cellAttributes[DocumentApp.Attribute.BACKGROUND_COLOR] = style.background;
+    cellAttributes[DocumentApp.Attribute.PADDING_TOP] = 10;
+    cellAttributes[DocumentApp.Attribute.PADDING_BOTTOM] = 10;
+    cellAttributes[DocumentApp.Attribute.PADDING_LEFT] = 10;
+    cellAttributes[DocumentApp.Attribute.PADDING_RIGHT] = 10;
+    cell.setAttributes(cellAttributes);
     cell.getParentTable().setBorderColor("#e0e0e0");
-    cell.setPaddingTop(10);
-    cell.setPaddingBottom(10);
-    cell.setPaddingLeft(10);
-    cell.setPaddingRight(10);
     let defaultStyle = style.defaultStyle;
     for (let para of segment.paragraphs) {
-      let text = para.editAsText();
-      if (defaultStyle.foreground) text.setForegroundColor(defaultStyle.foreground);
-      if (defaultStyle.background) text.setBackgroundColor(defaultStyle.background);
-      if (defaultStyle.fontFamily) text.setFontFamily(defaultStyle.fontFamily);
-      if (defaultStyle.bold !== undefined) text.setBold(defaultStyle.bold);
-      if (defaultStyle.italic !== undefined) text.setItalic(defaultStyle.italic);
+      applyStyleToWholeText(para.editAsText(), defaultStyle);
     }
   }
 }
 
-function applyCodeMirrorStyle(segmentStyle : theme.SegmentStyle, text : Text, start : number, token : string, cmStyle : string) {
-  let style = segmentStyle.codeMirrorStyleToStyle(cmStyle);
-  let endInclusive = start + token.length - 1;
-  applyStyle(text, start, endInclusive, style);
+type TextStyleRun = {
+  text : Text,
+  start : number,
+  endInclusive : number,
+  style : theme.Style,
+  key : string,
+};
+
+function styleKey(style : theme.Style) : string {
+  let values : Array<any> = [];
+  if (style.fontFamily) values.push("fontFamily", style.fontFamily);
+  if (style.foreground) values.push("foreground", style.foreground);
+  if (style.background) values.push("background", style.background);
+  if (style.bold !== undefined) values.push("bold", style.bold);
+  if (style.italic !== undefined) values.push("italic", style.italic);
+  return JSON.stringify(values);
+}
+
+function appendTextStyleRun(
+    runs : Array<TextStyleRun>,
+    text : Text,
+    start : number,
+    length : number,
+    style : theme.Style) {
+  if (length == 0) return;
+  let key = styleKey(style);
+  if (key == "[]") return;
+  let previous = runs.length == 0 ? null : runs[runs.length - 1];
+  if (previous &&
+      previous.text === text &&
+      previous.endInclusive + 1 == start &&
+      previous.key == key) {
+    previous.endInclusive += length;
+    return;
+  }
+  runs.push({
+    text: text,
+    start: start,
+    endInclusive: start + length - 1,
+    style: style,
+    key: key,
+  });
+}
+
+function applyTextStyleRuns(runs : Array<TextStyleRun>) {
+  for (let run of runs) {
+    applyStyle(run.text, run.start, run.endInclusive, run.style);
+  }
 }
 
 function highlightSegments(segments : Array<CodeSegment>) {
@@ -598,40 +641,38 @@ function highlightSegments(segments : Array<CodeSegment>) {
 function highlightSegment(segment : CodeSegment) {
   let paras = segment.paragraphs;
   let lines : Array<string> = [];
+  let texts : Array<{text : Text, offset : number}> = [];
   for (let para of paras) {
-    lines.push(...para.getText().split("\r"));
+    let content = para.getText();
+    let text = para.editAsText();
+    let offset = 0;
+    for (let line of content.split("\r")) {
+      lines.push(line);
+      texts.push({text: text, offset: offset});
+      offset += line.length + 1;
+    }
   }
-  let current_index = 0;  // The index of the current paragraph.
-  let offset = 0;  // The offset within the paragraph.
+  let lineIndex = 0;
+  let lineOffset = 0;
+  let runs : Array<TextStyleRun> = [];
   let segmentStyle = getModeToStyle().get(segment.mode);
   if (segmentStyle === undefined) return;  // This happens when the user wrote their own code segment.
   codemirror.runMode(lines, segmentStyle.codeMirrorMode, function(token, style) {
-    let current = paras[current_index];
-    let str = current.getText();
-    if (offset === str.length) {
-      if (token != "\n" || style !== null) {
-        throw "Unexpected token";
-      }
-      current_index++;
-      offset = 0;
+    if (token == "\n") {
+      lineIndex++;
+      lineOffset = 0;
       return;
     }
-    let text = current.editAsText();
-    applyCodeMirrorStyle(segmentStyle, text, offset, token, style);
-    offset += token.length;
+    let current = texts[lineIndex];
+    appendTextStyleRun(
+        runs,
+        current.text,
+        current.offset + lineOffset,
+        token.length,
+        segmentStyle!.codeMirrorStyleToStyleDelta(style));
+    lineOffset += token.length;
   });
-}
-
-// Assumes that the element is part of the document.
-// We don't check that the parent eventually ends up being the document.
-function computeElementPath(element : Element) : string {
-  let result = "";
-  while (true) {
-    let parent = element.getParent();
-    if (!parent) return result;
-    result += ":" + parent.getChildIndex(element);
-    element = parent;
-  }
+  applyTextStyleRuns(runs);
 }
 
 const HEADINGS = {
@@ -641,24 +682,22 @@ const HEADINGS = {
   "####": DocumentApp.ParagraphHeading.HEADING3,
 }
 
-function highlightCodeSpansAndHeadings(segments : Array<CodeSegment>) {
-  let inCodeSegments = new Set<string>();
+function highlightCodeSpansAndHeadings(
+    segments : Array<CodeSegment>, paragraphs : Array<Paragraph>) {
+  let inCodeSegments = new Set<Paragraph>();
 
   // Mark the paragraphs that are inside a code segment, so we don't change
   // them.
   for (let segment of segments) {
     for (let para of segment.paragraphs) {
-      inCodeSegments.add(computeElementPath(para));
+      inCodeSegments.add(para);
     }
   }
 
-  // We don't change the headings right away, as this would change the paths
-  // of the paragraphs.
-  // Instead we record the changes we would like to do, and then do them
-  // once we have run through all paragraphs.
+  // Record heading changes and apply them after scanning every paragraph.
   let headingsToChange : Array<any> = [];
-  for (let para of DocumentApp.getActiveDocument().getBody().getParagraphs()) {
-    if (inCodeSegments.has(computeElementPath(para))) {
+  for (let para of paragraphs) {
+    if (inCodeSegments.has(para)) {
       continue;
     }
     let text = para.getText();
@@ -733,15 +772,25 @@ function highlightCodeSpan(para : Paragraph, startTick : number, endTick : numbe
   text.deleteText(startTick, startTick);
 }
 
+function documentAttributesForStyle(style : theme.Style) : any {
+  let attributes : any = {};
+  if (style.fontFamily) attributes[DocumentApp.Attribute.FONT_FAMILY] = style.fontFamily;
+  if (style.foreground) attributes[DocumentApp.Attribute.FOREGROUND_COLOR] = style.foreground;
+  if (style.background) attributes[DocumentApp.Attribute.BACKGROUND_COLOR] = style.background;
+  if (style.bold !== undefined) attributes[DocumentApp.Attribute.BOLD] = style.bold;
+  if (style.italic !== undefined) attributes[DocumentApp.Attribute.ITALIC] = style.italic;
+  return attributes;
+}
+
+function applyStyleToWholeText(text : docs.Text, style : theme.Style) {
+  let attributes = documentAttributesForStyle(style);
+  if (Object.keys(attributes).length == 0) return;
+  text.setAttributes(attributes);
+}
+
 function applyStyle(text : docs.Text, start : number, endInclusive : number, style : theme.Style) {
-  if (!style) {
-    // Shouldn't happen with the current theme, but we treat this
-    // as "don't change anything".
-    return;
-  }
-  if (style.fontFamily) text.setFontFamily(start, endInclusive, style.fontFamily);
-  if (style.foreground) text.setForegroundColor(start, endInclusive, style.foreground);
-  if (style.background) text.setBackgroundColor(start, endInclusive, style.background);
-  if (style.bold !== undefined) text.setBold(start, endInclusive, style.bold);
-  if (style.italic !== undefined) text.setItalic(start, endInclusive, style.italic);
+  if (start > endInclusive) return;
+  let attributes = documentAttributesForStyle(style);
+  if (Object.keys(attributes).length == 0) return;
+  text.setAttributes(start, endInclusive, attributes);
 }

--- a/slides/syntax.ts
+++ b/slides/syntax.ts
@@ -108,8 +108,8 @@ class CodeShape {
     return new CodeShape(shape, mode);
   }
 
-  static fromText(shape : Shape) : CodeShape {
-    let str = shape.getText().asString();
+  static fromText(shape : Shape, text : TextRange) : CodeShape {
+    let str = text.asString();
     let lineEnd = indexOfLineSeparator(str);
     let firstLine = str.substring(0, lineEnd);
     let mode = firstLine.substring(3).trim();  // Skip the triple-quotes.
@@ -191,14 +191,6 @@ function colorizeSelectionAs(mode : string) {
   let text = selection.getTextRange();
   if (!text) return;
   if (text.isEmpty()) return;
-  let textStyle = text.getTextStyle();
-  let style = getModeToStyle().get(mode)!;
-  let defaultStyle = style.defaultStyle;
-  if (defaultStyle.fontFamily) textStyle.setFontFamily(defaultStyle.fontFamily);
-  if (defaultStyle.foreground) textStyle.setForegroundColor(defaultStyle.foreground);
-  if (defaultStyle.background) textStyle.setBackgroundColor(defaultStyle.background);
-  if (defaultStyle.bold !== undefined) textStyle.setBold(defaultStyle.bold);
-  if (defaultStyle.italic !== undefined) textStyle.setItalic(defaultStyle.italic);
   colorizeText(text, mode)
 }
 
@@ -210,7 +202,9 @@ function changeColorOfPageElement(pageElement : PageElement, mode : string) {
     let codeShape = CodeShape.fromBoxed(shape);
     codeShape.mode = mode;
     boxShape(codeShape);  // Applies the color.
-    colorizeCodeShape(codeShape);
+    let text = getShapeText(shape);
+    if (!text) return;
+    colorizeCodeShape(codeShape, text);
   } else if (pageElement.getPageElementType() == SlidesApp.PageElementType.GROUP) {
     pageElement.asGroup().getChildren().forEach(function(pe) {
       changeColorOfPageElement(pe, mode);
@@ -250,17 +244,24 @@ function doShape(shape : Shape) {
   let codeShape : CodeShape;
   if (isBoxedCodeShape(shape)) {
     codeShape = CodeShape.fromBoxed(shape);
-    colorizeCodeShape(codeShape);
-  } else if (isTextCodeShape(shape)) {
-    codeShape = CodeShape.fromText(shape);
+    let text = getShapeText(shape);
+    if (!text) return;
+    colorizeCodeShape(codeShape, text);
+    return;
+  }
+
+  let text = getShapeText(shape);
+  if (!text) return;
+  if (isTextCodeShape(text)) {
+    codeShape = CodeShape.fromText(shape, text);
     if (!getModeToStyle().has(codeShape.mode)) return
     // Box first, as this makes it easier to apply text styles.
     // GAS doesn't like it when there is no text.
     boxShape(codeShape);
-    removeTripleBackticks(codeShape);
-    colorizeCodeShape(codeShape);
+    removeTripleBackticks(text);
+    colorizeCodeShape(codeShape, text);
   } else {
-    colorizeSpans(shape);
+    colorizeSpans(text);
   }
 }
 
@@ -291,9 +292,7 @@ function getShapeText(shape : Shape) : TextRange | null {
   }
 }
 
-function isTextCodeShape(shape : Shape) : boolean {
-  let text = getShapeText(shape);
-  if (!text) return false;
+function isTextCodeShape(text : TextRange) : boolean {
   let str = text.asString();
   if (!str.startsWith("```")) return false;
   let lastTicksN = str.lastIndexOf('\n```');
@@ -310,16 +309,6 @@ function boxShape(codeShape : CodeShape) {
   let shape = codeShape.shape;
   let style = getModeToStyle().get(codeShape.mode)!;
   shape.getFill().setSolidFill(style.background);
-
-  let text = shape.getText();
-  if (text.isEmpty()) return;
-  let textStyle = text.getTextStyle();
-  let defaultStyle = style.defaultStyle;
-  if (defaultStyle.fontFamily) textStyle.setFontFamily(defaultStyle.fontFamily);
-  if (defaultStyle.foreground) textStyle.setForegroundColor(defaultStyle.foreground);
-  if (defaultStyle.background) textStyle.setBackgroundColor(defaultStyle.background);
-  if (defaultStyle.bold !== undefined) textStyle.setBold(defaultStyle.bold);
-  if (defaultStyle.italic !== undefined) textStyle.setItalic(defaultStyle.italic);
 }
 
 function indexOfLineSeparator(str : string) : number {
@@ -330,9 +319,7 @@ function indexOfLineSeparator(str : string) : number {
   return Math.min(n, v);
 }
 
-function removeTripleBackticks(codeShape : CodeShape) {
-  let shape = codeShape.shape;
-  let text = shape.getText();
+function removeTripleBackticks(text : TextRange) {
   let str = text.asString();
   let endOfFirstLine = indexOfLineSeparator(str);
   let startOfLastLineN = str.lastIndexOf('\n```');
@@ -347,29 +334,67 @@ function removeTripleBackticks(codeShape : CodeShape) {
   }
 }
 
-function colorizeCodeShape(codeShape : CodeShape) {
-  let shape = codeShape.shape;
-  let mode = codeShape.mode;
-  let text = shape.getText()
-  colorizeText(text, mode)
+function colorizeCodeShape(codeShape : CodeShape, text : TextRange) {
+  colorizeText(text, codeShape.mode)
+}
+
+type TextStyleRun = {
+  start : number,
+  end : number,
+  style : theme.Style,
+  key : string,
+};
+
+function styleKey(style : theme.Style) : string {
+  let values : Array<any> = [];
+  if (style.fontFamily) values.push("fontFamily", style.fontFamily);
+  if (style.foreground) values.push("foreground", style.foreground);
+  if (style.background) values.push("background", style.background);
+  if (style.bold !== undefined) values.push("bold", style.bold);
+  if (style.italic !== undefined) values.push("italic", style.italic);
+  return JSON.stringify(values);
+}
+
+function appendTextStyleRun(
+    runs : Array<TextStyleRun>, start : number, length : number, style : theme.Style) {
+  if (length == 0) return;
+  let key = styleKey(style);
+  if (key == "[]") return;
+  let previous = runs.length == 0 ? null : runs[runs.length - 1];
+  if (previous && previous.end == start && previous.key == key) {
+    previous.end += length;
+    return;
+  }
+  runs.push({
+    start: start,
+    end: start + length,
+    style: style,
+    key: key,
+  });
 }
 
 function colorizeText(text : TextRange, mode : string) {
   let str = text.asString();
+  if (str.length == 0) return;
   str = str.replace(/\x0B/g, "\n")
   let codeMirrorStyle = getModeToStyle().get(mode)!;
+  applyStyle(text, codeMirrorStyle.defaultStyle);
   let offset = 0;
+  let runs : Array<TextStyleRun> = [];
   codemirror.runMode(str, codeMirrorStyle.codeMirrorMode, function(token : string, tokenStyle : string) {
-    let range = text.getRange(offset, offset + token.length);
-    let style = codeMirrorStyle.codeMirrorStyleToStyle(tokenStyle);
-    applyStyle(range, style)
+    appendTextStyleRun(
+        runs,
+        offset,
+        token.length,
+        codeMirrorStyle.codeMirrorStyleToStyleDelta(tokenStyle));
     offset += token.length;
   });
+  for (let run of runs) {
+    applyStyle(text.getRange(run.start, run.end), run.style);
+  }
 }
 
-function colorizeSpans(shape : Shape) {
-  let text = getShapeText(shape);
-  if (!text) return;
+function colorizeSpans(text : TextRange) {
   if (text.isEmpty()) return;
   let str = text.asString();
   let spans : Array<CodeSpan> = [];
@@ -399,7 +424,7 @@ function colorizeSpans(shape : Shape) {
   let themer = getThemer();
   for (let i = spans.length - 1; i >= 0; i--) {
     let span = spans[i];
-    let rangeText = text.asString().substring(span.from + 1, span.to)
+    let rangeText = str.substring(span.from + 1, span.to)
     let style = themer.getCodeSpanStyle(rangeText);
     // We change the section with the back-ticks, and then remove the ticks afterwards.
     // This way we never have to deal with empty strings.
@@ -411,6 +436,7 @@ function colorizeSpans(shape : Shape) {
 }
 
 function applyStyle(range : TextRange, style : theme.Style) {
+  if (styleKey(style) == "[]") return;
   let textStyle = range.getTextStyle();
   // For some reason we sometimes get "The object (gb66c79a860_0_8) has no text."
   // when setting the foreground. We can see that the text is "\x0a", but we

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,62 @@
+# Tests
+
+The local tests transpile the real Apps Script TypeScript with `ts2gas` and
+execute it in a Node VM with small mocks for the Google Docs and Slides
+services. This keeps the tests fast and deterministic while exercising the
+same functions that are deployed.
+
+Run them with:
+
+```sh
+cd tests
+npm ci
+npm test
+```
+
+## Demo fixtures
+
+`fixtures/demo.json` is a compact text fixture derived from the demo Document
+and Presentation. It contains the fenced code modes, code-span examples,
+malformed delimiters, and Slides text shapes that use both newline and
+vertical-tab separators. Tests do not contact Google or modify the live demos.
+
+The source documents are recorded in the fixture so it can be refreshed
+manually when the demos change. Export the Document as DOCX and the
+Presentation as PPTX, then update only the relevant text cases. Do not commit
+the exported Office files.
+
+## What is covered
+
+- Mode and delimiter recognition using the demo content.
+- Empty and malformed backtick segments.
+- Empty Docs code spans.
+- Retrying transient Docs selection failures.
+- A missing Slides page-element range.
+- Shapes for which Slides rejects `getText()`.
+- Invalid custom theme colors.
+- Batched Docs attributes and coalesced token style runs.
+- Applying Slides defaults once and coalescing syntax deltas.
+
+## End-to-end testing
+
+The production add-ons use `documents.currentonly` and
+`presentations.currentonly`. That is desirable for users, but it means an API
+execution cannot call `openById()` on a fixture. A `clasp run` invocation also
+has no active editor context, so `getActiveDocument()` or
+`getActivePresentation()` cannot target one of the demos.
+
+Use disposable copies for a real smoke test:
+
+1. Deploy the development versions of the theme, CodeMirror, and add-on.
+2. Make copies of the demo Document and Presentation.
+3. Open each copy and invoke **Colorize** from the add-on menu.
+4. Confirm that headings, spans, fenced blocks, empty blocks, tables, groups,
+   and vertical-tab line breaks still render correctly.
+5. Check the Apps Script execution log for errors and compare execution time.
+6. Delete the copies.
+
+Fully automated Drive integration testing would require a separate test-only
+Apps Script project with broader Docs, Slides, and Drive scopes. That harness
+should create a copy, invoke test-specific code against it, assert the result,
+and delete the copy. Those broader scopes should not be added to the production
+add-ons.

--- a/tests/app-script-loader.js
+++ b/tests/app-script-loader.js
@@ -1,0 +1,29 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+async function loadAppScript(relativePath, globals = {}) {
+  const {default: ts2gas} = await import("ts2gas");
+  const sourcePath = path.resolve(__dirname, "..", relativePath);
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const context = vm.createContext({
+    console: {
+      log() {},
+      error() {},
+    },
+    theme: {
+      getModeList() {
+        return [];
+      },
+    },
+    ...globals,
+  });
+  vm.runInContext(ts2gas(source), context, {filename: sourcePath});
+  return {
+    context,
+    evaluate(expression) {
+      return vm.runInContext(expression, context);
+    },
+  };
+}
+
+module.exports = {loadAppScript};

--- a/tests/docs.test.js
+++ b/tests/docs.test.js
@@ -1,0 +1,205 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const {loadAppScript} = require("./app-script-loader");
+
+const fixture = JSON.parse(fs.readFileSync(
+    path.join(__dirname, "fixtures", "demo.json"), "utf8"));
+
+const ElementType = {
+  PARAGRAPH: "PARAGRAPH",
+  TABLE: "TABLE",
+};
+
+const Attribute = {
+  FONT_FAMILY: "FONT_FAMILY",
+  FOREGROUND_COLOR: "FOREGROUND_COLOR",
+  BACKGROUND_COLOR: "BACKGROUND_COLOR",
+  BOLD: "BOLD",
+  ITALIC: "ITALIC",
+};
+
+function fakeParagraph(text) {
+  const paragraph = {
+    getType() {
+      return ElementType.PARAGRAPH;
+    },
+    asParagraph() {
+      return paragraph;
+    },
+    getText() {
+      return text;
+    },
+  };
+  return paragraph;
+}
+
+function fakeBody(paragraphs) {
+  return {
+    getNumChildren() {
+      return paragraphs.length;
+    },
+    getChild(index) {
+      return paragraphs[index];
+    },
+  };
+}
+
+async function loadDocs(globals = {}) {
+  return loadAppScript("docs/syntax.ts", {
+    codemirror: globals.codemirror || {license: "test", runMode() {}},
+    DocumentApp: {
+      Attribute,
+      ElementType,
+      ParagraphHeading: {
+        TITLE: "TITLE",
+        HEADING1: "HEADING1",
+        HEADING2: "HEADING2",
+        HEADING3: "HEADING3",
+      },
+      ...globals.DocumentApp,
+    },
+    Utilities: globals.Utilities || {sleep() {}},
+  });
+}
+
+test("demo document discovers every well-formed fenced mode", async () => {
+  const app = await loadDocs();
+  const findCodeSegments = app.evaluate("findCodeSegments");
+  const text = fixture.document.blocks.flatMap(
+      block => [...block.paragraphs, "paragraph between blocks"]);
+  const inputParagraphs = text.map(fakeParagraph);
+  const visitedParagraphs = [];
+
+  const segments = findCodeSegments(fakeBody(inputParagraphs), visitedParagraphs);
+
+  assert.deepEqual(
+      Array.from(segments, segment => segment.mode),
+      fixture.document.blocks.map(block => block.mode));
+  assert.equal(visitedParagraphs.length, inputParagraphs.length);
+});
+
+test("malformed or incomplete backtick blocks are left untouched", async () => {
+  const app = await loadDocs();
+  const removeBackticks = app.evaluate("removeBackticks");
+
+  for (const block of fixture.document.malformedBlocks) {
+    let edits = 0;
+    const paragraphs = block.map(content => ({
+      getText() {
+        return content;
+      },
+      editAsText() {
+        edits++;
+        throw new Error("malformed block must not be edited");
+      },
+      removeFromParent() {
+        edits++;
+        throw new Error("malformed block must not be removed");
+      },
+    }));
+    removeBackticks({paragraphs});
+    assert.equal(edits, 0);
+  }
+});
+
+test("an empty code span does not address index zero", async () => {
+  const app = await loadDocs();
+  const highlightCodeSpan = app.evaluate("highlightCodeSpan");
+  const text = {
+    getText() {
+      return "";
+    },
+    setAttributes() {
+      throw new Error("empty text must not be styled");
+    },
+    deleteText() {
+      throw new Error("empty text must not be edited");
+    },
+  };
+
+  assert.doesNotThrow(() => highlightCodeSpan({editAsText: () => text}, 0, 0));
+});
+
+test("selection lookup retries transient Document service failures", async () => {
+  let attempts = 0;
+  const sleeps = [];
+  const expectedSelection = {id: "selection"};
+  const app = await loadDocs({
+    DocumentApp: {
+      getActiveDocument() {
+        return {
+          getSelection() {
+            attempts++;
+            if (attempts < 3) throw new Error("transient Document service failure");
+            return expectedSelection;
+          },
+        };
+      },
+    },
+    Utilities: {
+      sleep(delay) {
+        sleeps.push(delay);
+      },
+    },
+  });
+
+  assert.equal(app.evaluate("getActiveSelection")(), expectedSelection);
+  assert.equal(attempts, 3);
+  assert.deepEqual(sleeps, [100, 300]);
+});
+
+test("Docs styles are batched into one setAttributes call", async () => {
+  const app = await loadDocs();
+  const applyStyle = app.evaluate("applyStyle");
+  const calls = [];
+  const text = {
+    setAttributes(...args) {
+      calls.push(args);
+    },
+  };
+
+  applyStyle(text, 2, 8, {
+    fontFamily: "Roboto Mono",
+    foreground: "#112233",
+    background: "#ffffff",
+    bold: false,
+    italic: true,
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][0], 2);
+  assert.equal(calls[0][1], 8);
+  assert.deepEqual({...calls[0][2]}, {
+    FONT_FAMILY: "Roboto Mono",
+    FOREGROUND_COLOR: "#112233",
+    BACKGROUND_COLOR: "#ffffff",
+    BOLD: false,
+    ITALIC: true,
+  });
+});
+
+test("adjacent identical Docs token styles are coalesced", async () => {
+  const app = await loadDocs();
+  const appendTextStyleRun = app.evaluate("appendTextStyleRun");
+  const applyTextStyleRuns = app.evaluate("applyTextStyleRuns");
+  const calls = [];
+  const text = {
+    setAttributes(...args) {
+      calls.push(args);
+    },
+  };
+  const runs = [];
+
+  appendTextStyleRun(runs, text, 0, 3, {foreground: "#ff0000"});
+  appendTextStyleRun(runs, text, 3, 2, {foreground: "#ff0000"});
+  appendTextStyleRun(runs, text, 5, 1, {});
+  appendTextStyleRun(runs, text, 6, 2, {bold: true});
+
+  assert.equal(runs.length, 2);
+  assert.equal(runs[0].endInclusive, 4);
+  applyTextStyleRuns(runs);
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls.map(call => call.slice(0, 2)), [[0, 4], [6, 7]]);
+});

--- a/tests/fixtures/demo.json
+++ b/tests/fixtures/demo.json
@@ -1,0 +1,57 @@
+{
+  "sources": {
+    "document": "https://docs.google.com/document/d/1e611r8Jws6FqDe5DiRAsrLsKfFRr5AdojMR_lC_t8-o/edit",
+    "slides": "https://docs.google.com/presentation/d/1UhDXBJDUOytKy1lcdD7-Cc_AP3C0YILYbzGqpnXeKR4/edit"
+  },
+  "document": {
+    "codeSpans": [
+      "Use backticks to write `code` or constants: `12.3`.",
+      "path: `some/path`",
+      "number: `12`, `0.` or `.123` or `0.123`, but not `0.1.3`",
+      "strings: `\"foo\"`, or string/char: `'bar'`.",
+      "keywords: `null`, `undefined`, `true`, `false`, `nil`.",
+      "ipv4: `127.0.0.1`, but not `127.0.0.1.1`",
+      "Multiple `code spans` on the same line `foo bar`, while `` and ``` are ignored"
+    ],
+    "blocks": [
+      {"mode": "none", "paragraphs": ["```", "No syntax coloring.", "```"]},
+      {"mode": "js", "paragraphs": ["``` js", "function hello() {", "  console.log(\"hello world\");", "}", "```"]},
+      {"mode": "python", "paragraphs": ["``` python", "# Simple example.", "print(\"hello world\")", "```"]},
+      {"mode": "dart", "paragraphs": ["``` dart", "hello() {", "  print(\"hello world\");", "}", "```"]},
+      {"mode": "json", "paragraphs": ["``` json", "{", "  \"key\": [ \"value\", 1.23, true ]", "}", "```"]},
+      {"mode": "yaml", "paragraphs": ["``` yaml", "hello: world", "or: \"with string\"", "num: 3.14", "```"]},
+      {"mode": "c", "paragraphs": ["``` c", "#include <stdio.h>", "int main() {", "  return 0;", "}", "```"]},
+      {"mode": "c++", "paragraphs": ["``` c++", "#include <iostream>", "int main() {", "  return 0;", "}", "```"]},
+      {"mode": "go", "paragraphs": ["``` go", "package main", "func main() {", "    fmt.Println(\"hello world\")", "}", "```"]},
+      {"mode": "shell", "paragraphs": ["``` shell", "WHO=world", "echo \"hello $WHO\"", "```"]},
+      {"mode": "kotlin", "paragraphs": ["``` kotlin", "fun main(args: Array<String>) {", "  println(\"Hello, world!\")", "}", "```"]},
+      {"mode": "ts", "paragraphs": ["``` ts", "function hello(who : string) {", "  console.log(\"hello\" + who);", "}", "```"]},
+      {"mode": "java", "paragraphs": ["``` java", "class HelloWorld {", "  public static void main(String[] args) {}", "}", "```"]},
+      {"mode": "toit", "paragraphs": ["``` toit", "main:", "  print \"hello world\"", "```"]},
+      {"mode": "objective-c", "paragraphs": ["``` objective-c", "#import <Foundation/Foundation.h>", "int main() {", "  NSLog(@\"hello world\");", "}", "```"]},
+      {"mode": "scala", "paragraphs": ["``` scala", "object Hello {", "  def main() = println(\"hello world\")", "}", "```"]},
+      {"mode": "html", "paragraphs": ["``` html", "<!DOCTYPE html>", "<p>hello world</p>", "```"]},
+      {"mode": "xml", "paragraphs": ["``` xml", "<?xml version=\"1.0\"?>", "<foo>hello world</foo>", "```"]},
+      {"mode": "css", "paragraphs": ["``` css", "p {", "  color: green;", "}", "```"]},
+      {"mode": "jsx", "paragraphs": ["``` jsx", "let foo = (bar) => <a>{bar}</a>;", "```"]},
+      {"mode": "dockerfile", "paragraphs": ["``` dockerfile", "FROM ubuntu:18.04", "COPY . /app", "```"]},
+      {"mode": "sql", "paragraphs": ["``` sql", "SELECT name FROM employees", "ORDER BY name;", "```"]},
+      {"mode": "none", "paragraphs": ["```", "```"]},
+      {"mode": "dart", "paragraphs": ["``` dart", "```"]}
+    ],
+    "malformedBlocks": [
+      ["``` shellecho \"ok\"```"],
+      ["``` dart"],
+      ["```", "last entry without a closing delimiter"]
+    ]
+  },
+  "slides": [
+    {"slide": 2, "shapes": ["Some `title` with `code`", "``` toit\nfoo bar:\n  while true: print \"foo\"\n```", "```\n\n\n\n```", "```\n```", "`foo`", "``` dart\nmain() {\n  print(\"hello world\");\n}\n```"]},
+    {"slide": 3, "shapes": ["``` dart\nmain() {\n}\n```"]},
+    {"slide": 4, "shapes": ["Without backticks", "\u000b// some comment.\u000bmain:\u000b  print \"hello world\"\n\n// same, but with real new lines.\nmain:\n  print \"hello world\""]},
+    {"slide": 5, "shapes": ["yaml", "``` yaml\nfoo: bar\n```", "``` sql\nSELECT * FROM foo\n```"]},
+    {"slide": 6, "shapes": [" Code Spans", "path: `some/path`\nnumbers: `12`, `0.`, `0.123`\nstrings: `\"foo\"`, `'bar'`\nkeywords: `null`, `undefined`\nipv4: `127.0.0.1`\nmisc: `some` `code`", "Also works in `shapes`"]},
+    {"slide": 7, "shapes": ["Code Syntax", "Spans: Use backticks to write `code` or constants: `12.3`", "``` dart\u000bvoid main() {\u000b  print(\"Hello world\");\u000b}\u000b```", "``` ts\u000blet message: string= 'hello world';\u000bconsole.log(message);\u000b```", "``` go\u000bfunc hi() error {\u000b  return nil\u000b}\u000b```", "``` toit\u000bprint \"hello world\"\u000b```"]},
+    {"slide": 8, "shapes": ["Code Syntax", "Spans: Use backticks to write `code` or constants: `12.3`", "``` ts\nmessage : string = 'hello world'\nconsole.log(message)\n```", "Spans in `shapes`", "``` go\nfunc hi() error {\u000b  return nil\u000b}\n```", "``` toit\nmain:\n  print \"hello world\"\n```", "``` python\n# simple example\nprint(\"hello world\")\n```"]}
+  ]
+}

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,0 +1,54 @@
+{
+  "name": "code-syntax-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "code-syntax-tests",
+      "devDependencies": {
+        "ts2gas": "4.2.0"
+      }
+    },
+    "node_modules/ts2gas": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ts2gas/-/ts2gas-4.2.0.tgz",
+      "integrity": "sha512-5xZugaeM3wKQPj/vrWnrtYjNh4xnIz6cGSW/smCe9OTmkh1+KvHpm7M7HLq/OnBaljf4+yKctC4AYimBi4T1/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^2.1.0",
+        "typescript": "^4.4.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "code-syntax-tests",
+  "private": true,
+  "scripts": {
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "ts2gas": "4.2.0"
+  }
+}

--- a/tests/slides.test.js
+++ b/tests/slides.test.js
@@ -1,0 +1,130 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const {loadAppScript} = require("./app-script-loader");
+
+const fixture = JSON.parse(fs.readFileSync(
+    path.join(__dirname, "fixtures", "demo.json"), "utf8"));
+
+function slidesGlobals(overrides = {}) {
+  return {
+    SlidesApp: {
+      ShapeType: {TEXT_BOX: "TEXT_BOX"},
+      PageElementType: {SHAPE: "SHAPE", GROUP: "GROUP"},
+      ...overrides.SlidesApp,
+    },
+    codemirror: overrides.codemirror || {runMode() {}},
+  };
+}
+
+test("demo slides recognize newline and vertical-tab code shapes", async () => {
+  const app = await loadAppScript("slides/syntax.ts", slidesGlobals());
+  const isTextCodeShape = app.evaluate("isTextCodeShape");
+  const CodeShape = app.evaluate("CodeShape");
+  const modes = [];
+
+  for (const slide of fixture.slides) {
+    for (const shapeText of slide.shapes) {
+      const text = {asString: () => shapeText};
+      if (isTextCodeShape(text)) {
+        modes.push(CodeShape.fromText({}, text).mode);
+      }
+    }
+  }
+
+  assert.deepEqual(modes, [
+    "toit", "none", "none", "dart",
+    "dart",
+    "yaml", "sql",
+    "dart", "ts", "go", "toit",
+    "ts", "go", "toit", "python",
+  ]);
+});
+
+test("changing color with no selected page elements is a no-op", async () => {
+  const app = await loadAppScript("slides/syntax.ts", slidesGlobals({
+    SlidesApp: {
+      getActivePresentation() {
+        return {
+          getSelection() {
+            return {getPageElementRange: () => null};
+          },
+        };
+      },
+    },
+  }));
+
+  assert.doesNotThrow(() => app.evaluate("changeColorTo")("dart"));
+});
+
+test("shapes that reject getText are skipped", async () => {
+  const app = await loadAppScript("slides/syntax.ts", slidesGlobals());
+  const getShapeText = app.evaluate("getShapeText");
+  const doShape = app.evaluate("doShape");
+  const inaccessibleShape = {
+    getShapeType() {
+      return "NOT_A_TEXT_BOX";
+    },
+    getText() {
+      throw new Error("Slides service rejected getText");
+    },
+  };
+
+  assert.equal(getShapeText(inaccessibleShape), null);
+  assert.doesNotThrow(() => doShape(inaccessibleShape));
+});
+
+test("Slides applies defaults once and coalesces identical token deltas", async () => {
+  const fullStyleCalls = [];
+  const rangeStyleCalls = [];
+  const ranges = [];
+  const textStyle = calls => ({
+    setFontFamily(value) { calls.push(["fontFamily", value]); },
+    setForegroundColor(value) { calls.push(["foreground", value]); },
+    setBackgroundColor(value) { calls.push(["background", value]); },
+    setBold(value) { calls.push(["bold", value]); },
+    setItalic(value) { calls.push(["italic", value]); },
+  });
+  const text = {
+    asString() {
+      return "abcd ";
+    },
+    getTextStyle() {
+      return textStyle(fullStyleCalls);
+    },
+    getRange(start, end) {
+      ranges.push([start, end]);
+      return {getTextStyle: () => textStyle(rangeStyleCalls)};
+    },
+  };
+  const segmentStyle = {
+    codeMirrorMode: "demo",
+    defaultStyle: {
+      fontFamily: "Roboto Mono",
+      foreground: "#000000",
+      bold: false,
+      italic: false,
+    },
+    codeMirrorStyleToStyleDelta(style) {
+      return style === "keyword" ? {foreground: "#ff0000"} : {};
+    },
+  };
+  const app = await loadAppScript("slides/syntax.ts", slidesGlobals({
+    codemirror: {
+      runMode(_source, _mode, callback) {
+        callback("ab", "keyword");
+        callback("cd", "keyword");
+        callback(" ", null);
+      },
+    },
+  }));
+  app.context.testSegmentStyle = segmentStyle;
+  app.evaluate("getModeToStyle = function() { return new Map([['demo', testSegmentStyle]]); }");
+
+  app.evaluate("colorizeText")(text, "demo");
+
+  assert.equal(fullStyleCalls.length, 4);
+  assert.deepEqual(ranges, [[0, 4]]);
+  assert.deepEqual(rangeStyleCalls, [["foreground", "#ff0000"]]);
+});

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -1,0 +1,47 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {loadAppScript} = require("./app-script-loader");
+
+test("syntax deltas exclude attributes already present in the default style", async () => {
+  const app = await loadAppScript("theme/theme.ts");
+  const result = app.evaluate(`(() => {
+    const style = new SegmentStyle(
+        "demo", "demo", "#ffffff",
+        {fontFamily: "Roboto Mono", foreground: "#000000", bold: false},
+        {keyword: {foreground: "#ff0000", bold: true}});
+    return {
+      plain: style.codeMirrorStyleToStyleDelta(null),
+      keyword: style.codeMirrorStyleToStyleDelta("keyword"),
+      fullKeyword: style.codeMirrorStyleToStyle("keyword"),
+    };
+  })()`);
+
+  assert.deepEqual(JSON.parse(JSON.stringify(result)), {
+    plain: {},
+    keyword: {foreground: "#ff0000", bold: true},
+    fullKeyword: {
+      fontFamily: "Roboto Mono",
+      foreground: "#ff0000",
+      bold: true,
+    },
+  });
+});
+
+test("invalid custom colors are rejected before reaching Apps Script setters", async () => {
+  const errors = [];
+  const app = await loadAppScript("theme/theme.ts", {
+    console: {
+      log() {},
+      error(message) {
+        errors.push(String(message));
+      },
+    },
+  });
+  app.context.invalidTheme = JSON.stringify({
+    default: {foreground: "not-a-color"},
+  });
+
+  assert.equal(app.evaluate("parseTheme(invalidTheme, 'test')"), null);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /Invalid color default\.foreground/);
+});

--- a/theme/theme.ts
+++ b/theme/theme.ts
@@ -208,6 +208,18 @@ class SegmentStyle {
     }
     return mergeStyles(this.defaultStyle, entry);
   }
+
+  // Returns only the attributes that differ from the default style. Callers
+  // can apply the default once and avoid reapplying it for every token.
+  public codeMirrorStyleToStyleDelta(cmStyle : string | null) : Style {
+    if (!cmStyle) return {};
+    let entry = this.syntax ? this.syntax[cmStyle] : undefined;
+    if (!entry) {
+      console.log("No entry for " + cmStyle);
+      return {};
+    }
+    return mergeStyles(entry);
+  }
 }
 
 class Themer {


### PR DESCRIPTION
## Summary

- batch Google Docs text and table attributes and avoid a second paragraph traversal
- apply default styles once, then coalesce and apply only syntax-style deltas
- reuse Slides text ranges and avoid repeated shape text reads
- add demo-derived fixtures and regression tests for the recently fixed error cases
- document local tests and the disposable-copy Drive smoke-test workflow

## Validation

- cd tests && npm test
- TypeScript type-check for Docs, Slides, and theme sources
- Apps Script ts2gas transpilation
- git diff --check

This is a performance and test-coverage follow-up to #38 and #37. It does not add OAuth scopes or a REST API dependency.